### PR TITLE
Switched chef provisioning to the docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM grahamc/jekyll
+COPY Gemfile /src/
+COPY Gemfile.lock /src/
+WORKDIR /src
+RUN bundle install

--- a/README.md
+++ b/README.md
@@ -1,19 +1,10 @@
-Requirements
-===
-
-- vagrant-berkshelf plugin v.1.2.0
-- vagrant-omnibus plugin v1.1.0
-
 Local installation
 ===
 
+Jekyll server is started by vagrant provision so all you have to do is just run `vagrant up`.  
+Or if you halted your machine you could just run `vagrant up --provision` to start a jekyll or you can always start it manually:
 ```bash
-git clone --recursive https://github.com/dointeractive/dointeractive.github.com
-# for already initialized repo use
-# git submodule update --init --recursive
 vagrant up
 vagrant ssh
-cd /vagrant
-bundle
-bundle exec jekyll serve --watch
+docker start jekyll
 ```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,21 +1,13 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-# cause submodules is too mainstream
-if Dir['cookbooks/*'].empty?
-  `git clone -b dointeractive-github-com https://github.com/dointeractive/cookbooks`
-end
-
 Vagrant.configure('2') do |config|
-  config.vm.box = 'chef/ubuntu-12.04'
-  config.vm.synced_folder '.', '/vagrant', type: 'nfs'
+  config.vm.box = 'chef/ubuntu-14.04'
   config.vm.network :private_network, ip: '10.0.0.215'
+  config.vm.synced_folder ".", "/vagrant", type: 'nfs'
 
-  config.vm.provision :chef_solo do |chef|
-    chef.add_recipe 'site'
+  config.vm.provision :docker do |d|
+    d.build_image '/vagrant', args: '-t jekyll'
+    d.run 'jekyll', cmd: 'serve', args: '-p 80:4000 -v /vagrant:/src'
   end
-
-  config.berkshelf.enabled = true
-  config.berkshelf.berksfile_path = 'cookbooks/Berksfile'
-  config.omnibus.chef_version = :latest
 end


### PR DESCRIPTION
Now all you have to do to start develop is to type `vagrant up`